### PR TITLE
Update flashz.hpp

### DIFF
--- a/src/flashz.hpp
+++ b/src/flashz.hpp
@@ -29,13 +29,29 @@
 
 
 #pragma once
+
+// arduino-esp32 core 2.x => 3.x migration
 #if __has_include("miniz.h")
-  #include "miniz.h"
+    #include "miniz.h"
 #else
-  #include <rom/miniz.h>
+    #include <rom/miniz.h>
 #endif
+
 #include <Update.h>
 #include <functional>
+
+// arduino-esp32 core 2.x => 3.x migration
+#if !defined SPI_FLASH_SEC_SIZE
+    #include "spi_flash_mmap.h"
+#endif
+
+// arduino-esp32 core 2.x => 3.x migration
+#if __has_include(<NetworkClient.h>)
+    #include <NetworkClient.h>
+    #define WiFiClient NetworkClient
+#else
+    #include <WiFiClient.h>
+#endif
 
 #ifndef ESP_IMAGE_HEADER_MAGIC
 #define ESP_IMAGE_HEADER_MAGIC  0xE9

--- a/src/flashz.hpp
+++ b/src/flashz.hpp
@@ -29,7 +29,11 @@
 
 
 #pragma once
-#include <rom/miniz.h>
+#if __has_include("miniz.h")
+  #include "miniz.h"
+#else
+  #include <rom/miniz.h>
+#endif
 #include <Update.h>
 #include <functional>
 


### PR DESCRIPTION
fix for deprecation warning (arduino-esp32 3.x.x):

```log
/home/runner/.arduino15/packages/esp32/tools/esp32-arduino-libs/idf-release_v5.1-442a798083/esp32/include/esp_rom/include/esp32/rom/miniz.h:7:2: warning: #warning "{target}/rom/miniz.h is deprecated, please use (#include "miniz.h") instead" [-Wcpp]
      7 | #warning "{target}/rom/miniz.h is deprecated, please use (#include "miniz.h") instead"
```
fix for UpdateClass related error (arduino-esp32 3.x.x):

```log
/home/runner/Arduino/libraries/esp32-flashz/src/flashz.cpp:289:23: error: 'SPI_FLASH_SEC_SIZE' was not declared in this scope; did you mean 'SPI_FLASH_BLOCK_SIZE'?
```
fix for networkclient related error (arduino-esp32 3.x.x):

```log
/home/runner/Arduino/libraries/esp32-flashz/src/flashz-http.cpp:207:5: error: 'WiFiClient' was not declared in this scope
    207 |     WiFiClient *stream = http.getStreamPtr();
```